### PR TITLE
Fixing sticky vote buttons & some other minor changes

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -978,16 +978,17 @@ var features = { //ALL the functions must go in here
         function stickcells(){
             $votecells.each(function() {
                 var $topbar = $('.topbar'),
+                    topbarHeight = $topbar.outerHeight(),
                     offset = 10;
                 if ($topbar.css('position') == 'fixed') {
-                    offset += $topbar.outerHeight();
+                    offset += topbarHeight;
                 }
                 var $voteCell = $(this),
                     $vote = $voteCell.find('.vote'),
                     vcOfset = $voteCell.offset(),
                     scrollTop = $(window).scrollTop();
                 if (vcOfset.top - scrollTop - offset <= 0) {
-                    if (vcOfset.top + $voteCell.height() - scrollTop - offset - $vote.height() > 34) {
+                    if (vcOfset.top + $voteCell.height() - scrollTop - offset - $vote.height() > topbarHeight) {
                         $vote.css({
                             position: 'fixed',
                             left: vcOfset.left + 4,

--- a/sox.features.js
+++ b/sox.features.js
@@ -117,7 +117,7 @@ var features = { //ALL the functions must go in here
 
     fixedTopbar: function() {
         // Description: For making the topbar fixed (always stay at top of screen)
-        if ($(location).attr('hostname') == 'askubuntu.com') { //AskUbuntu is annoying. UnicornsAreVeryVeryYummy made the below code for AskUbuntu: https://github.com/shu8/Stack-Overflow-Optional-Features/issues/11 Thanks!
+        if (location.hostname == 'askubuntu.com') { //AskUbuntu is annoying. UnicornsAreVeryVeryYummy made the below code for AskUbuntu: https://github.com/shu8/Stack-Overflow-Optional-Features/issues/11 Thanks!
             var newUbuntuLinks = $('<div/>', {
                     class: 'fixedTopbar-links'
                 }),
@@ -977,24 +977,27 @@ var features = { //ALL the functions must go in here
 
         function stickcells(){
             $votecells.each(function() {
-                var offset = 0;
-                if ($('.topbar').css('position') == 'fixed') {
-                    offset = 34;
+                var $topbar = $('.topbar'),
+                    offset = 10;
+                if ($topbar.css('position') == 'fixed') {
+                    offset += $topbar.outerHeight();
                 }
-                var vote = $(this).find('.vote');
-                //var post_contents = $(this).next('td.postcell, td.answercell');
-                if ($(this).offset().top - $(window).scrollTop() + offset <= 0) {
-                    if ($(this).offset().top + $(this).height() - $(window).scrollTop() + offset - vote.height() > 34) {
-                        vote.css({
+                var $voteCell = $(this),
+                    $vote = $voteCell.find('.vote'),
+                    vcOfset = $voteCell.offset(),
+                    scrollTop = $(window).scrollTop();
+                if (vcOfset.top - scrollTop - offset <= 0) {
+                    if (vcOfset.top + $voteCell.height() - scrollTop - offset - $vote.height() > 34) {
+                        $vote.css({
                             position: 'fixed',
-                            left: $(this).offset().left + 4,
-                            top: 10 + offset
+                            left: vcOfset.left + 4,
+                            top: offset
                         });
                     } else {
-                        vote.removeAttr("style");
+                        $vote.removeAttr("style");
                     }
                 } else {
-                    vote.removeAttr("style");
+                    $vote.removeAttr("style");
                 }
             });
         }

--- a/sox.user.js
+++ b/sox.user.js
@@ -18,13 +18,13 @@
 // @require      https://cdn.rawgit.com/timdown/rangyinputs/master/rangyinputs-jquery-src.js
 // @require      https://cdn.rawgit.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js
 // @require      https://cdn.rawgit.com/camagu/jquery-feeds/master/jquery.feeds.js
-// @require      https://rawgit.com/soscripted/sox/experimental/sox.helpers.js
-// @require      https://rawgit.com/soscripted/sox/experimental/sox.features.js
-// @require      https://rawgit.com/soscripted/sox/experimental/themes/sox.themeeditor.js
-// @require      https://rawgit.com/soscripted/sox/experimental/themes/sox.theming.js
-// @require      https://rawgit.com/soscripted/sox/experimental/chat/sox.chat.js
-// @resource     settingsDialog https://rawgit.com/soscripted/sox/experimental/sox.dialog.html
-// @resource     themeEditor https://rawgit.com/soscripted/sox/experimental/themes/sox.themeeditor.html
+// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.helpers.js
+// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.features.js
+// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.themeeditor.js
+// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.theming.js
+// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/chat/sox.chat.js
+// @resource     settingsDialog https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.dialog.html
+// @resource     themeEditor https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.themeeditor.html
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_deleteValue

--- a/sox.user.js
+++ b/sox.user.js
@@ -19,7 +19,7 @@
 // @require      https://cdn.rawgit.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js
 // @require      https://cdn.rawgit.com/camagu/jquery-feeds/master/jquery.feeds.js
 // @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.helpers.js
-// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.features.js
+// @require      https://github.com/DJDavid98/sox/raw/sticky-vote-btn-fix/sox.features.js
 // @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.themeeditor.js
 // @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.theming.js
 // @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/chat/sox.chat.js

--- a/sox.user.js
+++ b/sox.user.js
@@ -60,14 +60,15 @@
     }
 
     function isDeprecated() { //checks whether the saved settings contain a deprecated feature
-        //TODO: add function names to an array and loop instead of || .. || .. ||
-        var settings = getSettings();
-        if (settings.indexOf('answerCountSidebar') != -1 ||
-            settings.indexOf('highlightClosedQuestions') != -1 ||
-            settings.indexOf('unHideAnswer') != -1 ||
-            settings.indexOf('flaggingPercentages') != -1) {
-            return true;
-        }
+        var settings = getSettings(),
+            deprecatedFeatures = [
+                'answerCountSidebar',
+                'highlightClosedQuestions',
+                'unHideAnswer',
+                'flaggingPercentages',
+                'moveCommentsLink',
+            ];
+        return (new RegExp('('+deprecatedFeatures.join('|')+')')).test(settings);
     }
 
     function addFeatures(features) {

--- a/sox.user.js
+++ b/sox.user.js
@@ -18,13 +18,13 @@
 // @require      https://cdn.rawgit.com/timdown/rangyinputs/master/rangyinputs-jquery-src.js
 // @require      https://cdn.rawgit.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js
 // @require      https://cdn.rawgit.com/camagu/jquery-feeds/master/jquery.feeds.js
-// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.helpers.js
-// @require      https://github.com/DJDavid98/sox/raw/sticky-vote-btn-fix/sox.features.js
-// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.themeeditor.js
-// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.theming.js
-// @require      https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/chat/sox.chat.js
-// @resource     settingsDialog https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/sox.dialog.html
-// @resource     themeEditor https://rawgit.com/DJDavid98/sox/sticky-vote-btn-fix/themes/sox.themeeditor.html
+// @require      https://rawgit.com/soscripted/sox/experimental/sox.helpers.js
+// @require      https://rawgit.com/soscripted/sox/experimental/sox.features.js
+// @require      https://rawgit.com/soscripted/sox/experimental/themes/sox.themeeditor.js
+// @require      https://rawgit.com/soscripted/sox/experimental/themes/sox.theming.js
+// @require      https://rawgit.com/soscripted/sox/experimental/chat/sox.chat.js
+// @resource     settingsDialog https://rawgit.com/soscripted/sox/experimental/sox.dialog.html
+// @resource     themeEditor https://rawgit.com/soscripted/sox/experimental/themes/sox.themeeditor.html
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_deleteValue


### PR DESCRIPTION
I've fixed the sticky voting buttons' positioning and made its code a bit more optimized (#2). There was also a silly access to `location.hostname` using jQuery which I've simplified, and I also saved you the hassle of creating a loop when it's not even necessary. You also forgot to add `moveCommentsLink` to the list of deprecated options, that's also been fixed along with the non-loop check.

Let me know if you'd like me to compress the commits into 1 to keep the repo's history clean.