### PR TITLE
Fixing sticky vote buttons & some other minor changes

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -116,7 +116,7 @@ var features = { //ALL the functions must go in here
 
     fixedTopbar: function() {
         // Description: For making the topbar fixed (always stay at top of screen)
-        if ($(location).attr('hostname') == 'askubuntu.com') { //AskUbuntu is annoying. UnicornsAreVeryVeryYummy made the below code for AskUbuntu: https://github.com/shu8/Stack-Overflow-Optional-Features/issues/11 Thanks!
+        if (location.hostname == 'askubuntu.com') { //AskUbuntu is annoying. UnicornsAreVeryVeryYummy made the below code for AskUbuntu: https://github.com/shu8/Stack-Overflow-Optional-Features/issues/11 Thanks!
             var head = document.getElementsByTagName('head')[0],
                 ubuntuLinks = document.getElementsByClassName('nav-global')[0],
                 remove = document.getElementById('custom-header'),
@@ -1004,23 +1004,28 @@ var features = { //ALL the functions must go in here
 
         function stickcells(){
             $votecells.each(function() {
-                var offset = 0;
-                if ($(".topbar").css("position") == "fixed") {
-                    offset = 34;
+                var $topbar = $('.topbar'),
+                    topbarHeight = $topbar.outerHeight(),
+                    offset = 10;
+                if ($topbar.css('position') == 'fixed') {
+                    offset += topbarHeight;
                 }
-                var vote = $(this).find(".vote");
-                if ($(this).offset().top - $(window).scrollTop() + offset <= 0) {
-                    if ($(this).offset().top + $(this).height() - $(window).scrollTop() + offset - vote.height() > 0) {
-                        vote.css({
-                            position: "fixed",
-                            left: $(this).offset().left + 4,
-                            top: 10 + offset
+                var $voteCell = $(this),
+                    $vote = $voteCell.find('.vote'),
+                    vcOfset = $voteCell.offset(),
+                    scrollTop = $(window).scrollTop();
+                if (vcOfset.top - scrollTop - offset <= 0) {
+                    if (vcOfset.top + $voteCell.height() - scrollTop - offset - $vote.height() > topbarHeight) {
+                        $vote.css({
+                            position: 'fixed',
+                            left: vcOfset.left + 4,
+                            top: offset
                         });
                     } else {
-                        vote.removeAttr("style");
+                        $vote.removeAttr("style");
                     }
                 } else {
-                    vote.removeAttr("style");
+                    $vote.removeAttr("style");
                 }
             });
         }

--- a/sox.user.js
+++ b/sox.user.js
@@ -135,14 +135,15 @@
     }
 
     function isDeprecated() { //checks whether the saved settings contain a deprecated feature
-        //TODO: add function names to an array and loop instead of || .. || .. ||
-        settings = getSettings();
-        if (settings.indexOf('answerCountSidebar') != -1 ||
-            settings.indexOf('highlightClosedQuestions') != -1 ||
-            settings.indexOf('unHideAnswer') != -1 ||
-            settings.indexOf('flaggingPercentages') != -1) {
-            return true;
-        }
+        var settings = getSettings(),
+            deprecatedFeatures = [
+                'answerCountSidebar',
+                'highlightClosedQuestions',
+                'unHideAnswer',
+                'flaggingPercentages',
+                'moveCommentsLink',
+            ];
+        return (new RegExp('('+deprecatedFeatures.join('|')+')')).test(settings);
     }
 
     function addFeatures(features) {


### PR DESCRIPTION
I've fixed the sticky voting buttons' positioning and made its code a bit more optimized (#2). There was also a silly access to `location.hostname` using jQuery which I've simplified, and I also saved you the hassle of creating a loop when it's not even necessary. You also forgot to add moveCommentsLink to the list of deprecated options, that's also been fixed along with the non-loop check.

*This is a re-submission of #14 based off of the `dev` branch instead, as requested by @shu8*