### PR TITLE
Comment reply buttons change comment width

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -567,7 +567,7 @@
                     if (!$(this).find('.soxReplyLink').length) { //if the link doesn't already exist
                         if ($('.topbar-links a span:eq(0)').text() != $(this).find('.comment-text a.comment-user').text()) { //make sure the link is not added to your own comments
                             $(this).find('.comment-text').css('overflow-x', 'hidden');
-                            $(this).append('<span class="soxReplyLink" title="reply to this user">&crarr;</span>');
+                            $(this).append('<span class="soxReplyLink" title="reply to this user" style="margin-left: -7px">&crarr;</span>');
                         }
                     }
                 });


### PR DESCRIPTION
This prevents reply buttons from cutting off some of the comment's border, and shortening the comment's width.