### PR TITLE
Add new option to remove the user ID from the 'share' link.

### DIFF
--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -394,6 +394,13 @@
             "match": "*://*/questions*,*://*/review*",
             "exclude": "SE1.0"
         }, {
+            "name": "shareLinksPrivacy",
+            "desc": "Remove your user ID from the 'share' link",
+            "extended_description": "When you click 'share' under a post, this displays a referral link, which incorporates your user ID. This option strips your user ID from the displayed link, preventing inadvertent privacy leaks when disseminating the link via copy-paste. The social-media sharing buttons are unaffected, since the lack of privacy is obvious.",
+            "meta": "https://meta.stackexchange.com/questions/74274/privacy-leak-in-permalink",
+            "match": "*://*/questions*,*://*/review*",
+            "exclude": "SE1.0"
+        }, {
             "name": "shareLinksMarkdown",
             "desc": "Change 'share' link to format of [post-name](url)",
             "extended_description": "When you click 'share' under a post, this will convert the URL given to a markdown-friendly version, with the post name as the link text. This feature also automatically copies the converted string to your clipboard",

--- a/sox.features.js
+++ b/sox.features.js
@@ -486,6 +486,25 @@
             });
         },
 
+        shareLinksPrivacy: function() {
+            // Description: Remove your user ID from the 'share' link
+
+            sox.helpers.observe('.share-tip', function() {
+                const toRemove = ' (includes your user id)';
+                var popup = $('.share-tip');
+                var origHtml = popup.html();
+                if (origHtml.indexOf(toRemove) == -1) return; //don't do anything if the function's already done its thing
+                popup.html(function () {
+                    return origHtml.replace(toRemove, '');
+                });
+                
+                var inputBox = $('.share-tip input'),
+                    origLink = inputBox.val();
+                inputBox.val(origLink.match(/.+\/(q|a)\/[0-9]+/g));
+                inputBox.select();
+            });
+        },
+
         shareLinksMarkdown: function() {
             // Description: For changing the 'share' button link to the format [name](link)
 


### PR DESCRIPTION
Introduces a new feature to the SOX menu that allows automatically stripping the user ID from the post link that is generated when you click "share" underneath a post.

This is important to me in many cases where I want to use a link but still maintain my anonymity. I sometimes forget to remove the user ID. I'd like to be done automatically.

This does not affect the links shared on social media sites when you click the buttons at the bottom of the "share" pop-up. There are no privacy concerns there, since you're posting it on social media using your account!

I also tested this with the existing feature to add the post title in Markdown format, and it works fine. All four combinations are possible. In other words, this doesn't break anything!