### PR TITLE
improvements in colorAnswers

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -253,12 +253,19 @@
         colorAnswerer: function() {
             // Description: For highlighting the names of answerers on comments
 
+            var CSS_TO_SET = {
+                'color': 'rgba(0, 50, 200, 1)',
+                'background-color': 'rgba(220, 220, 220, 1)',
+                'padding': '1px 5px'
+            };
+
             function colour() {
+                var answererID;
+                
                 $('.answercell').each(function(i, obj) {
-                    $(this).parent().next().find('.comment-user:contains("' + $.trim($(this).find('.user-details').last().clone().children('.-flair').remove().end().text()) + '")').css({
-                        'background-color': '#f9e2b6',
-                        'padding': '1px 5px'
-                    }); //Find the comments on each post that contain the answerer's name. Also, .last() is necessary, or else it will use the name of someone who edits the answer.
+                    answererID = +this.querySelector('.post-signature:nth-last-of-type(1) a[href^="/users"]').href.match(/\d+/)[0];
+
+                    $(this.nextElementSibling.querySelector('.comment-user[href^="/users/' + answererID + '"]')).css(CSS_TO_SET);
                 });
             }
 

--- a/sox.features.js
+++ b/sox.features.js
@@ -259,17 +259,17 @@
                 'padding': '1px 5px'
             };
 
-            function colour() {
+            function color() {
                 var answererID;
                 
                 $('.answercell').each(function(i, obj) {
                     answererID = +this.querySelector('.post-signature:nth-last-of-type(1) a[href^="/users"]').href.match(/\d+/)[0];
 
-                    $(this.nextElementSibling.querySelector('.comment-user[href^="/users/' + answererID + '"]')).css(CSS_TO_SET);
+                    $(this.nextElementSibling.querySelectorAll('.comment-user[href^="/users/' + answererID + '"]')).css(CSS_TO_SET);
                 });
             }
 
-            colour();
+            color();
             $(document).on('sox-new-comment', colour);
         },
 


### PR DESCRIPTION
#343 

1. constant variables+cache answeredID
2. reduce jQuery dependency+shorter a[href] selector via user ID
3. change coloration

**Why did I change the colors?**

Have a look at this picture to understand:

![image](https://user-images.githubusercontent.com/6308683/42370228-d3c23586-8129-11e8-80ef-57fc459275a9.png)

Basically, the main motivation for the answerer highlighting is to be in the same pattern with the current question highlighting. The previous configuration was a blue text color on a yellow background. Not only is this a bright background color to use in contrast with a dark text color, but it also is inconsistent with the existing highlighting for questioner's comments (dark text over light background, both being of same shade).

Feel free to discuss about the colors though, I'm not a color expert :P (In fact, I think even a 0.6 opaque light grey background on the default text color would also work)

----

(the second commit just makes the spelling of color consistent and also uses the `All` selector that I forgot earlier)