### PR TITLE
Replace use of RawGit with jsDelivr

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -1081,7 +1081,7 @@
 
       function addCSS() {
         $('.js-vote-up-btn, .js-vote-down-btn, .js-favorite-btn').addClass('sox-better-css');
-        $('head').append('<link rel="stylesheet" href="https://rawgit.com/shu8/SE-Answers_scripts/master/coolMaterialDesignCss.css" type="text/css" />');
+        $('head').append('<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/shu8/SE-Answers_scripts@master/coolMaterialDesignCss.css" type="text/css" />');
         $('#hmenus').css('-webkit-transform', 'translateZ(0)');
       }
       addCSS();

--- a/sox.user.js
+++ b/sox.user.js
@@ -9,7 +9,7 @@
 // @contributor  ᔕᖺᘎᕊ (https://stackexchange.com/users/4337810/, https://github.com/shu8)
 // @contributor  Sir-Cumference (https://stackexchange.com/users/4119142/, https://github.com/Sir-Cumference)
 // @contributor  GaurangTandon (https://github.com/GaurangTandon)
-// @updateURL    https://rawgit.com/soscripted/sox/dev/sox.user.js
+// @updateURL    https://cdn.jsdelivr.net/gh/soscripted/sox@dev/sox.user.js
 
 // @match        *://*.stackoverflow.com/*
 // @match        *://*.stackexchange.com/*


### PR DESCRIPTION
Fixes #382 by replacing use of RawGit URLs with jsDelivr, which is functionally equivalent.