### PR TITLE
Remove the Hide HNQ option from SOX

### DIFF
--- a/sox.css
+++ b/sox.css
@@ -492,12 +492,6 @@
     padding: 1px 5px !important;
 }
 
-/*hotNetworkQuestionsFiltering -- for the questions to hide*/
-
-.sox-hot-network-question-filter-hide {
-    display: none !important;
-}
-
 /*addAuthorNameToInboxNotifications -- for the author span*/
 
 .sox-notification-author {

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -336,12 +336,6 @@
             "match": "",
             "exclude": "*://chat.*.com/*"
         }, {
-            "name": "hideHotNetworkQuestions",
-            "desc": "Hide the Hot Network Questions module",
-            "meta": "",
-            "match": "",
-            "exclude": "*://chat.*.com/*"
-        }, {
             "name": "linkedToFrom",
             "desc": "Add an arrow to linked posts in the sidebar to show whether they are linked to or linked from",
             "meta": "http://meta.stackexchange.com/q/276235/260841",

--- a/sox.features.js
+++ b/sox.features.js
@@ -1621,12 +1621,6 @@
       });
     },
 
-    hideHotNetworkQuestions: function() {
-      // Description: Hides the Hot Network Questions module from the sidebar
-
-      $('#hot-network-questions').remove();
-    },
-
     hideHireMe: function() {
       // Description: Hides the Looking for a Job module from the sidebar
 


### PR DESCRIPTION
**Feature**
Remove the Hide Hot Network Questions module option.

**Related issue**
There isn't a related issue here, just a [meta post](https://meta.stackexchange.com/a/325061).

**Description of changes**
This entirely removes the Hide the Hot Network Questions module, since Stack Exchange has added an option for the user to disable it in user profile's page.