### PR TITLE
Remove the isQuestionHot option from SOX

### DIFF
--- a/sox.css
+++ b/sox.css
@@ -247,15 +247,6 @@
     content: "No new meta questions at this time.";
 }
 
-/*addHotText for the 'this question is hot' banner */
-
-.sox-hot {
-    float: left;
-    font-size: xx-large;
-    color: red;
-    margin-right: 8px;
-}
-
 /*quickCommentShortcutsMain: */
 
 .quickCommentShortcutsReminder {

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -58,13 +58,6 @@
             "exclude": "*://chat.*.com/*,*://*/questions/*",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
-            "name": "isQuestionHot",
-            "desc": "Add a label on questions which are hot-network questions",
-            "extended_description": "If the question you are currently viewing is HOT, a flame icon is added next to the title",
-            "meta": "http://meta.stackexchange.com/questions/245390/let-mods-and-10k-know-when-questions-go-hot",
-            "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask"
-        }, {
             "name": "localTimestamps",
             "desc": "Convert timestamps to your local time",
             "extended_description": "Displays timestamps based on your time zone. You can also display time in 12-hour format by checking the option.",

--- a/sox.features.js
+++ b/sox.features.js
@@ -731,43 +731,6 @@
       });
     },
 
-    isQuestionHot: function() {
-      // Description: For adding some text to questions that are in the hot network questions list
-
-      function addHotText() {
-        if (!document.getElementsByClassName('sox-hot').length) {
-          document.getElementById('feed').innerHTML = '<p>SOX: One of the 100 hot network questions!</p>';
-
-          //display:block to fix https://github.com/soscripted/sox/issues/243:
-          $(document.getElementById('question-header')).css('display', 'block').prepend('<div title="SOX: this is a hot network question!" ' + (sox.location.on('english.stackexchange.com') ? 'style="padding:13px"' : '') + ' class="sox-hot"><i class="fab fa-free-code-camp"></i><div>');
-        }
-      }
-      $(document.getElementById('qinfo')).after('<div id="feed"></div>');
-
-      if (sox.location.on('/questions') || $('.question-summary').length) {
-        const proxyUrl = 'https://cors-anywhere.herokuapp.com/'; //CORS proxy
-        const hnqJSONUrl = 'https://stackexchange.com/hot-questions-for-mobile';
-        const requestUrl = proxyUrl + hnqJSONUrl;
-
-        $.get(requestUrl, results => {
-          if (sox.location.on('/questions/')) {
-            $.each(results, (i, o) => {
-              if (document.URL.indexOf(o.site + '/questions/' + o.question_id) > -1) addHotText();
-            });
-          } else {
-            $('.question-summary').each(function() {
-              const id = $(this).attr('id').split('-')[2];
-              if (results.filter(d => {
-                return d.question_id == id;
-              }).length) {
-                $(this).find('.summary h3').prepend('<div title="SOX: this question is a hot network question!" class="sox-hot" style="font-size:x-large;float:none;display:inline"><i class="fab fa-free-code-camp"></i></div>');
-              }
-            });
-          }
-        });
-      }
-    },
-
     localTimestamps: function(settings) {
       // Description: Gets local timestamp
 


### PR DESCRIPTION
The  option is now no longer needed as per [this MSE post](https://meta.stackexchange.com/q/324641/435726) and therefore I went forward and removed it.

I am not sure, though, if it was really appropriate. The current design is more obvious than SE's one, so people can understand faster if a question is HNQ or not.

The final say is yours, of course.