### PR TITLE
Do not change the span's title when having the option to convert timestamps to local time enables

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -812,7 +812,7 @@
 
         const newTimestamp = (new Date()).getFullYear() == date.getFullYear() ? month + ' ' + date.getDate() + ' at ' + hour + ':' + minute + dayTime : month + ' ' + date.getDate() + ' \'' + year + ' at ' + hour + ':' + minute + dayTime;
 
-        $(this).attr('title', newTimestamp).text(newTimestamp);
+        $(this).text(newTimestamp);
       }
     },
 


### PR DESCRIPTION
It is known that the time a post is posted is inside a `<span>` tag:

![image](https://user-images.githubusercontent.com/38133098/59622432-37b12e00-913a-11e9-95e7-b1b3bae3d77e.png)

where the HTML code is:

![image](https://user-images.githubusercontent.com/38133098/59622484-557e9300-913a-11e9-8dcd-d8fcf4e2ad34.png)

However, if the option "Convert timestamps to your local time", it affects the `title` **to be the same as `span`'s text**. This is something I can't allow, since I am using another userscript which should fetch the time a post was posted **originally, at UTC and in the time format `YYYY-MM-DD HH:MM:SSZ`**.

There was a line which originally replaced both the `title` and the `text` with the `newTimestamp`. I have removed the `attr()`, so now only the `span` text is replaced.

Does that hurt? AFAIK, this `title` isn't used elsewhere in SOX, so, it is OK removing it, right?