### PR TITLE
CSS improvements

### DIFF
--- a/sox.css
+++ b/sox.css
@@ -447,7 +447,7 @@
     text-align: center;
 }
 
-.main {
+.sox-flagPercentProgressBar-container {
     background-color: #fafafb
 }
 

--- a/sox.css
+++ b/sox.css
@@ -430,7 +430,7 @@
 #sox-flagPercentProgressBar {
     background: #ccc;
     height: 10px;
-    width: 220px;
+    width: 250px;
     margin: 6px 10px 10px 0;
     padding: 0px;
     margin: auto;
@@ -445,6 +445,10 @@
 #sox-flagPercentHelpful {
     margin-bottom: 5px;
     text-align: center;
+}
+
+.main {
+    background-color: #fafafb
 }
 
 /*titleEditDiff -- for the toggle button*/

--- a/sox.features.js
+++ b/sox.features.js
@@ -2317,10 +2317,11 @@
                       width: ${percentHelpful}%;
                     }`);
 
-        $('#flag-summary-filter').after('<h3 id=\'sox-flagPercentHelpful\' title=\'only helpful and declined flags are counted\'><span id=\'percent\'>' + percentHelpful + '%</span> helpful</h3>');
+        $('#flag-summary-filter').after('<h3 id=\'sox-flagPercentHelpful\' title=\'only helpful and declined flags are counted\' class=\'wrap-div\'><span id=\'percent\'>' + percentHelpful + '%</span> helpful</h3>');
         $('#sox-flagPercentHelpful span#percent').css('color', percentColor);
 
-        $('#sox-flagPercentHelpful').after('<div id=\'sox-flagPercentProgressBar\'></div>');
+        $('#sox-flagPercentHelpful').after('<div id=\'sox-flagPercentProgressBar\' class=\'wrap-div\'></div>');
+        $('.wrap-div').wrapAll("<div class='main'></div>")
       }
     },
 

--- a/sox.features.js
+++ b/sox.features.js
@@ -2321,7 +2321,7 @@
         $('#sox-flagPercentHelpful span#percent').css('color', percentColor);
 
         $('#sox-flagPercentHelpful').after('<div id=\'sox-flagPercentProgressBar\' class=\'wrap-div\'></div>');
-        $('.wrap-div').wrapAll("<div class='.sox-flagPercentProgressBar-container'></div>")
+        $('.wrap-div').wrapAll("<div class='sox-flagPercentProgressBar-container'></div>")
       }
     },
 

--- a/sox.features.js
+++ b/sox.features.js
@@ -2321,7 +2321,7 @@
         $('#sox-flagPercentHelpful span#percent').css('color', percentColor);
 
         $('#sox-flagPercentHelpful').after('<div id=\'sox-flagPercentProgressBar\' class=\'wrap-div\'></div>');
-        $('.wrap-div').wrapAll("<div class='main'></div>")
+        $('.wrap-div').wrapAll("<div class='.sox-flagPercentProgressBar-container'></div>")
       }
     },
 


### PR DESCRIPTION
- Wrap all the stuff the userscript creates into a `div` with class `main`.
- Set the background of `.main` (actually what the userscript will show) to colour `#fafafb` which is the same as the `Your flagging history` background colour.
- Increase the `width` of the bar to `250px`, so that people with 99.5%+ accuracy can see more easily how much space is remaining.

Preview:

![image](https://user-images.githubusercontent.com/38133098/59629266-1b69bd00-914b-11e9-8066-3b99270e1687.png)

Kinda better (IMO) than:

![image](https://user-images.githubusercontent.com/38133098/59629397-684d9380-914b-11e9-920f-e41bbd5894ac.png)

which hurts my eyes a bit.