### PR TITLE
Remove block display from #question-header

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -738,8 +738,7 @@
         if (!document.getElementsByClassName('sox-hot').length) {
           document.getElementById('feed').innerHTML = '<p>SOX: One of the 100 hot network questions!</p>';
 
-          //display:block to fix https://github.com/soscripted/sox/issues/243:
-          $(document.getElementById('question-header')).css('display', 'block').prepend('<div title="SOX: this is a hot network question!" ' + (sox.location.on('english.stackexchange.com') ? 'style="padding:13px"' : '') + ' class="sox-hot"><i class="fab fa-free-code-camp"></i><div>');
+          $(document.getElementById('question-header')).prepend('<div title="SOX: this is a hot network question!" ' + (sox.location.on('english.stackexchange.com') ? 'style="padding:13px"' : '') + ' class="sox-hot"><i class="fab fa-free-code-camp"></i><div>');
         }
       }
       $(document.getElementById('qinfo')).after('<div id="feed"></div>');


### PR DESCRIPTION
The block display from the `#question-header` allowed the <kbd>Ask Question</kbd> button to go in a new line. The fix for issue #243 is now obsolete, since it used `HOT!` and now it uses a fire icon.

Previous problematic design:

![image](https://user-images.githubusercontent.com/38133098/59696007-dea5d080-91f3-11e9-8313-2139f0ee6d35.png)

Fixed design:

![image](https://user-images.githubusercontent.com/38133098/59695822-8bcc1900-91f3-11e9-80c0-0eaa46c289b0.png)