### PR TITLE
Find if a question is a HNQ from API

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -712,8 +712,11 @@
         apiCall(postId, sitename);
       } else if ($('.question-summary').length) {
         $('.question-summary').each(function() {
-          const postID = $(this).attr('id').split('-')[2];
-          apiCall(postID, sitename, this);
+          // Check if .question-summary has an id attribute - SO Teams posts (at the top of the page, if any) don't!
+          if ($(this).attr('id')) {
+            var postID = $(this).attr('id').split('-')[2];
+            apiCall(postID, sitename, this);
+          }
         });
       }
       function apiCall(postID, sitename, el) {

--- a/sox.features.js
+++ b/sox.features.js
@@ -726,8 +726,8 @@
           featureId: 'isQuestionHot',
           cacheDuration: 60 * 8, // Cache for 8 hours
         }, results => {
-          $.each(results, (i, o) => {
-            if (results[i].comment === "<b>Became Hot Network Question</b> " && new Date().getTime() / 1000 - results[i].creation_date <= 259200) { // Questions stay hot for 3 days. Check if they are hot now (Note SE works with secs, not millisecs!)
+          results.forEach(data => {
+            if (data.comment === "<b>Became Hot Network Question</b> " && new Date().getTime() / 1000 - data.creation_date <= 259200) { // Questions stay hot for 3 days. Check if they are hot now (Note SE works with secs, not millisecs!)
               sox.location.on('/questions') ? addHotText() : $(el).find('.summary h3').prepend(getHotDiv('question-list'))
             }
           });

--- a/sox.features.js
+++ b/sox.features.js
@@ -705,28 +705,34 @@
         $(document.getElementById('question-header')).prepend(getHotDiv());
       }
 
-      if (sox.location.on('/questions') || $('.question-summary').length) {
-        const proxyUrl = 'https://cors-anywhere.herokuapp.com/'; //CORS proxy
-        const hnqJSONUrl = 'https://stackexchange.com/hot-questions-for-mobile';
-        const requestUrl = proxyUrl + hnqJSONUrl;
+      const sitename = sox.site.currentApiParameter;
 
-        $.get(requestUrl, results => {
-          if (sox.location.on('/questions/')) {
-            $.each(results, (i, o) => {
-              if (document.URL.indexOf(o.site + '/questions/' + o.question_id) > -1) addHotText();
-            });
-          } else {
-            $('.question-summary').each(function() {
-              const id = $(this).attr('id').split('-')[2];
-              if (results.filter(d => {
-                return d.question_id == id;
-              }).length) {
-                $(this).find('.summary h3').prepend(getHotDiv('question-list'));
-              }
-            });
-          }
-        });
+      if (sox.location.on('/questions')) {
+        const postId = window.location.pathname.split('/')[2]
+        apiCall(postId, sitename);
+      } else if ($('.question-summary').length) {
+          $('.question-summary').each(function() {
+              const postID = $(this).attr('id').split('-')[2];
+              apiCall(postID, sitename, this);
+          });
       }
+        function apiCall(postID, sitename, el) {
+            sox.helpers.getFromAPI({
+                endpoint: 'posts',
+                childEndpoint: 'revisions',
+                sitename: sitename,
+                filter: '!5RC-)9_aw3mg*i)3*vUhU3Wfl',
+                ids: postID,
+                featureId: 'isQuestionHot',
+                cacheDuration: 60 * 8, // Cache for 8 hours
+            }, results => {
+                $.each(results, (i, o) => {
+                    if (results[i].comment === "<b>Became Hot Network Question</b> " && new Date().getTime() / 1000 - results[i].creation_date <= 259200) { // Questions stay hot for 3 days. Check if they are hot now (Note SE works with secs, not millisecs!)
+                        sox.location.on('/questions') ? addHotText() : $(el).find('.summary h3').prepend(getHotDiv('question-list'))
+                    }
+                });
+            });
+        }
     },
 
     localTimestamps: function(settings) {

--- a/sox.features.js
+++ b/sox.features.js
@@ -716,23 +716,23 @@
               apiCall(postID, sitename, this);
           });
       }
-        function apiCall(postID, sitename, el) {
-            sox.helpers.getFromAPI({
-                endpoint: 'posts',
-                childEndpoint: 'revisions',
-                sitename: sitename,
-                filter: '!5RC-)9_aw3mg*i)3*vUhU3Wfl',
-                ids: postID,
-                featureId: 'isQuestionHot',
-                cacheDuration: 60 * 8, // Cache for 8 hours
-            }, results => {
-                $.each(results, (i, o) => {
-                    if (results[i].comment === "<b>Became Hot Network Question</b> " && new Date().getTime() / 1000 - results[i].creation_date <= 259200) { // Questions stay hot for 3 days. Check if they are hot now (Note SE works with secs, not millisecs!)
-                        sox.location.on('/questions') ? addHotText() : $(el).find('.summary h3').prepend(getHotDiv('question-list'))
-                    }
-                });
-            });
-        }
+      function apiCall(postID, sitename, el) {
+        sox.helpers.getFromAPI({
+          endpoint: 'posts',
+          childEndpoint: 'revisions',
+          sitename: sitename,
+          filter: '!5RC-)9_aw3mg*i)3*vUhU3Wfl',
+          ids: postID,
+          featureId: 'isQuestionHot',
+          cacheDuration: 60 * 8, // Cache for 8 hours
+        }, results => {
+          $.each(results, (i, o) => {
+            if (results[i].comment === "<b>Became Hot Network Question</b> " && new Date().getTime() / 1000 - results[i].creation_date <= 259200) { // Questions stay hot for 3 days. Check if they are hot now (Note SE works with secs, not millisecs!)
+              sox.location.on('/questions') ? addHotText() : $(el).find('.summary h3').prepend(getHotDiv('question-list'))
+            }
+          });
+        });
+      }
     },
 
     localTimestamps: function(settings) {

--- a/sox.features.js
+++ b/sox.features.js
@@ -711,10 +711,10 @@
         const postId = window.location.pathname.split('/')[2]
         apiCall(postId, sitename);
       } else if ($('.question-summary').length) {
-          $('.question-summary').each(function() {
-              const postID = $(this).attr('id').split('-')[2];
-              apiCall(postID, sitename, this);
-          });
+        $('.question-summary').each(function() {
+          const postID = $(this).attr('id').split('-')[2];
+          apiCall(postID, sitename, this);
+        });
       }
       function apiCall(postID, sitename, el) {
         sox.helpers.getFromAPI({


### PR DESCRIPTION
**This implements a feature request**

Before, the userscript checked if a question was hot from https://stackexchange.com/hot-questions-for-mobile. However, since mid-March, there's a revision item which says when a question became HNQ. This is also in the API as a comment: "<b>Became Hot Network Question</b> ".

Checking if there's such comment in the post (via revisions-by-ids method) and if its creation_date is shorter or equal to 259200 seconds (3 days) does what was done before.