### PR TITLE
Exclude SO Teams URL from markEmployees feature

### DIFF
--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -81,7 +81,7 @@
             "desc": "Add the SO logo after employee names to make them stand out",
             "meta": "http://meta.stackexchange.com/questions/246678/should-se-staff-have-a-special-character-in-their-user-name",
             "match": "",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://stackoverflow.com/c/*",
             "feature_packs": ["major_ui", "key_feature", "power_user"],
             "usesApi": true
         }, {


### PR DESCRIPTION
SO Teams doesn't have an API, so showing the SE logo in SO Teams is buggy (it shows it to every team admin or SE moderator, etc.) and unneded.