### PR TITLE
Improve sites' regex and fix bug with meta sites

### DIFF
--- a/sox.common.js
+++ b/sox.common.js
@@ -377,7 +377,7 @@
       return idMatch ? +idMatch[1] : null;
     },
     getSiteNameFromLink: function(link) {
-      const siteRegex = /(((.+)\.)?(stackexchange|stackoverflow|superuser|serverfault|askubuntu|stackapps|mathoverflow|programmers|bitcoin))\.com/;
+      const siteRegex = /(((.+)\.)?(((stackexchange|stackoverflow|superuser|serverfault|askubuntu|stackapps))(?=\.com))|mathoverflow\.net)/;
       const siteMatch = link.replace(/https?:\/\//, '').match(siteRegex);
       return siteMatch ? siteMatch[1] : null;
     },

--- a/sox.features.js
+++ b/sox.features.js
@@ -1003,7 +1003,15 @@
 
       const NEWQUESTIONS = 'metaNewQuestionAlert-lastQuestions';
       const favicon = sox.site.icon;
-      const metaName = 'meta.' + sox.site.currentApiParameter;
+      const sitename = sox.site.currentApiParameter;
+
+      // If it is a special site, add 'meta' before it, if not, replace the 'stackexchange' from the URL with 'meta'.
+      if (sitename.match(/stackoverflow|superuser|serverfault|askubuntu|stackapps|mathoverflow/)) {
+        var metaName = 'meta.' + sitename;
+      } else {
+        metaName = sitename.replace('stackexchange','meta');
+      }
+
       const FILTER_QUESTION_TITLE_LINK = '!BHMIbze0EQ*ved8LyoO6rNk25qGESy';
       const $dialog = $('<div/>', {
         id: 'metaNewQuestionAlertDialog',


### PR DESCRIPTION
1. There's no Programmers Stack Exchange site anymore. It has been replaced to Software Engineering and its URL is 'softwareengineering.stackexchange.com' which is already caught by the regex.
2. The Bitcoin site's URL is 'bitcoin.stackexchange.com' and not 'bitcoin.com', therefore it is already caught by that regex.
3. Mathoverflow is a special site, but it doesn't end in '.com', but in '.net', therefore it is moved to the second alternative
4. Positive lookahead is added to '.com' because the function is called to get the site name to use it in the API and API doesn't require '.com' at the end of sitenames. However, API doesn't accept 'meta.mathoverflow', but only 'meta.mathoverflow.net', so '.net' in second alternative doesn't have (?=).

The userscript, before, automatically added the prefix 'meta.' to every site to make an API call with it being the sitename. However, that's not true for non-special sites, where the 'meta' should come after the name and before the 'stackexchange'.

Since API also accepts the name of the site + the meta prefix, here, we replace 'stackexchange' with 'meta' instead of having more complex ways to add it after the name and before 'stackexchange'. If it is a special site, add naturally the 'meta.' prefix.