### PR TITLE
Share link privacy fix

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -469,9 +469,9 @@
       // Description: Remove your user ID from the 'share' link
 
       $('.post-menu .js-subtitle').remove(); // Remove the 'includes your user id' string
-      for (let i = 0; i < $('.js-share-link').length; i++) {
-          $('.js-share-link:eq(' + i + ')').attr("href", $('.js-share-link:eq(' + i + ')').attr('href').match(/\/(q|a)\/[0-9]+/)[0]);
-      }
+      $('.js-share-link').each((i, el) => {
+          el.href = el.href.match(/\/(q|a)\/[0-9]+/)[0];
+      });
     },
 
     shareLinksMarkdown: function() {

--- a/sox.features.js
+++ b/sox.features.js
@@ -468,7 +468,7 @@
     shareLinksPrivacy: function() {
       // Description: Remove your user ID from the 'share' link
 
-      $('.js-subtitle').remove(); // Remove the 'includes your user id' string
+      $('.post-menu .js-subtitle').remove(); // Remove the 'includes your user id' string
       for (let i = 0; i < $('.js-share-link').length; i++) {
           $('.js-share-link:eq(' + i + ')').attr("href", $('.js-share-link:eq(' + i + ')').attr('href').match(/\/(q|a)\/[0-9]+/)[0]);
       }

--- a/sox.features.js
+++ b/sox.features.js
@@ -468,27 +468,10 @@
     shareLinksPrivacy: function() {
       // Description: Remove your user ID from the 'share' link
 
-      const questionTarget = document.getElementById('question');
-      const answersTargets = document.getElementsByClassName('answer');
-      sox.helpers.observe([questionTarget, ...answersTargets], '.share-tip', () => {
-        const toRemove = ' (includes your user id)';
-        const popup = document.getElementsByClassName('share-tip')[0];
-        if (!popup) return;
-
-        // Do nothing if the function's already done its thing
-        const popupTextInfo = popup.querySelector('.js-text');
-        const origText = popupTextInfo.innerText;
-        if (origText.indexOf(toRemove) == -1) return;
-
-        const input = popup.querySelector('input');
-        const origLink = input.value;
-        const newLink = origLink.match(/.+\/(q|a)\/[0-9]+/g)[0];
-
-        popupTextInfo.innerText = origText.replace(toRemove, '');
-
-        input.value = newLink;
-        input.select();
-      });
+      $('.js-subtitle').remove(); // Remove the 'includes your user id' string
+      for (let i = 0; i < $('.js-share-link').length; i++) {
+          document.getElementsByClassName('js-share-link')[i].href = document.getElementsByClassName('js-share-link')[i].href.match(/.+\/(q|a)\/[0-9]+/)[0];
+      }
     },
 
     shareLinksMarkdown: function() {

--- a/sox.features.js
+++ b/sox.features.js
@@ -470,7 +470,7 @@
 
       $('.js-subtitle').remove(); // Remove the 'includes your user id' string
       for (let i = 0; i < $('.js-share-link').length; i++) {
-          document.getElementsByClassName('js-share-link')[i].href = document.getElementsByClassName('js-share-link')[i].href.match(/.+\/(q|a)\/[0-9]+/)[0];
+          $('.js-share-link:eq(' + i + ')').attr("href", $('.js-share-link:eq(' + i + ')').attr('href').match(/\/(q|a)\/[0-9]+/)[0]);
       }
     },
 


### PR DESCRIPTION
It appears that the new SE change of 'share' button in post-menu broke this function. I found that the link is obtained from share's href, so the code is simpler than the previous.