### PR TITLE
Check if selectionStart is less than selectionEnd and vice versa before the assignment

### DIFF
--- a/sox.common.js
+++ b/sox.common.js
@@ -443,8 +443,8 @@
         Note that `]` and `[` denote the selected text here.
     */
 
-      const selS = textarea.selectionStart;
-      const selE = textarea.selectionEnd;
+      const selS = textarea.selectionStart < textarea.selectionEnd ? textarea.selectionStart : textarea.selectionEnd;
+      const selE = textarea.selectionStart > textarea.selectionEnd ? textarea.selectionStart : textarea.selectionEnd;
       const value = textarea.value;
       const startLen = start.length;
       const endLen = end.length;


### PR DESCRIPTION
I tried to edit a post and I noticed there were some keys which needed `kbd` formatting. I selected the text and clicked `kbd`, but the result was strange. The text looked before:

![image](https://user-images.githubusercontent.com/38133098/64272299-be122a80-cf47-11e9-87d7-c41db70ec556.png)

Afterwards, it looked like:

![image](https://user-images.githubusercontent.com/38133098/64272379-e732bb00-cf47-11e9-8bd5-e800e0149986.png)

While in the desired result the `SHIFT`s should not have been there.

Interestingly, trying again worked, and worked and then failed. This seemed interesting on me, so I started testing to find the bug.

After a bit of digging, I realized there were 2 interesting variable assignments in `sox.common.js` `surroundSelectedText()` function:

    const selS = textarea.selectionStart;
    const selE = textarea.selectionEnd;

This however, doesn't seem write. What if I select the text with my cursor from right to left? Then `selS` would have `selectionEnd` and `selE` `selectionStart` *actually*. This appeared to produce the strange results.

A fix is to check if `selectionStart` is less than `selectionEnd` and vice versa and assign accordingly. After all, the feature now works regardless of how you select the text.