### PR TITLE
Check .comment-user's href before processing it

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -190,6 +190,7 @@
           const commentUsers = $(cell).next().next().find('.comments .comment-user');
 
           commentUsers.each(function() {
+            if (!this.href) return true;
             if (this.href.contains(`users/${answererID}`)) this.classList.add('sox-answerer');
           });
         }


### PR DESCRIPTION
If a user who has comment is deleted, then href is undefined, meaning that `this.href.contains` would throw error:

> Unable to get property 'contains' of undefined or null reference
