### PR TITLE
Exclude MSE from isQuestionHot feature

### DIFF
--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -63,7 +63,7 @@
             "extended_description": "If the question you are currently viewing is HOT, a flame icon is added next to the title",
             "meta": "http://meta.stackexchange.com/questions/245390/let-mods-and-10k-know-when-questions-go-hot",
             "match": "*://*/questions/*,*://*/search*,*://*/?",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "exclude": "SE1.0,*://*/questions/ask,*://meta.*/*"
         }, {
             "name": "localTimestamps",
             "desc": "Convert timestamps to your local time",


### PR DESCRIPTION
There aren't HNQs in Meta Stack Exchange nor in the meta sites.