### PR TITLE
Ignore the Community user and any negative userid

### DIFF
--- a/sox.features.js
+++ b/sox.features.js
@@ -1985,7 +1985,7 @@
             userid = sox.helpers.getIDFromAnchor(this);
             username = this.innerText;
 
-            if (userid !== 0) postAuthors[userid] = username;
+            if (userid > 0) postAuthors[userid] = username;
           } else {
             sox.loginfo('Could not find user user link for: ', this);
           }


### PR DESCRIPTION
SE API doesn't accept negative user IDs. As a result, if Community (id = -1) has edited a post or is an author of a post, the whole function fails.