### PR TITLE
Make matches and excludes more accurate

### DIFF
--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -35,7 +35,7 @@
             "extended_description": "Highlight the username of a commenter if they have posted an answer on that page.",
             "meta": "https://meta.stackexchange.com/q/19574",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
             "name": "displayName",
@@ -48,7 +48,7 @@
             "desc": "Make bounty box draggable",
             "meta": "https://meta.stackexchange.com/q/170125",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "highlightQuestions",
             "desc": "Change highlighting for questions with favourite tags",
@@ -111,7 +111,7 @@
             "desc": "Differentiate spoilers from empty blockquotes",
             "meta": "https://meta.stackexchange.com/q/104085",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "standOutDupeCloseMigrated",
             "desc": "Add highlighted tags to closed/on hold/duplicate/migrated questions on question lists",
@@ -133,19 +133,19 @@
             "desc": "Improve answer visibility by listing top answers",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "unspoil",
             "desc": "Add a link to the bottom of a post to reveal all spoilers in a post",
             "meta": "https://meta.stackexchange.com/q/249808",
-            "match": "*://*/questions/*,*://*/questions*?tab*,*://chat.*.com/*",
+            "match": "*://*/questions/*,*://*/questions*tab=*,*://chat.*.com/*",
             "exclude": "SE1.0"
         }, {
             "name": "addTimelineAndRevisionLinks",
             "desc": "Add timeline and revision links to the bottom of each post for quick access to them",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "showTagWikiLinkOnTagPopup",
@@ -172,7 +172,7 @@
             "extended_description": "When clicking on an image that is hosted on Stack Exchange's imgur account, a modal will open showing a larger version of the image. If you still want to open the image in a new tab, there is a 'source' link in the modal.",
             "meta": "",
             "match": "*://*/questions/*,*://*/review/*",
-            "exclude": "*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "*://*/questions*tab=*,*://chat.*.com/*"
         }],
         "Comments": [{
             "name": "autoShowCommentImages",
@@ -180,39 +180,39 @@
             "extended_description": "This feature will automatically detect comments with links to imgur and will display them inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "commentReplies",
             "desc": "Add reply links to comments for quick replying (without having to type someone's username)",
             "meta": "https://meta.stackexchange.com/q/74778",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "commentShortcuts",
             "desc": "Use Ctrl+I,B,K (to italicise, bolden and add code backticks) in comments",
             "meta": "https://meta.stackexchange.com/q/14756",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "confirmNavigateAway",
             "desc": "Add a confirmation dialog when navigating away on pages whilst still typing a comment",
             "meta": "https://meta.stackexchange.com/q/252205",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "copyCommentsLink",
             "desc": "Copy 'show x more comments' link to the top",
             "meta": "https://meta.stackexchange.com/q/55020",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "moveBounty",
             "desc": "Move the 'start a bounty' link to before the comments",
             "meta": "https://meta.stackexchange.com/q/234095",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "showCommentScores",
             "desc": "Show your comment and comment replies scores in your profile tabs",
@@ -226,14 +226,14 @@
             "desc": "Add a darker border underneath comments if there are some hidden after it",
             "meta": "https://meta.stackoverflow.com/q/296582",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "onlyShowCommentActionsOnHover",
             "desc": "Only show the comment actions (flag/upvote) when hovering over a comment",
             "meta": "https://meta.stackexchange.com/q/312794",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }],
         "Editing": [{
             "name": "addSBSBtn",
@@ -241,7 +241,7 @@
             "extended_description": "An 'SBS' button is added to the right of the markdown editor toolbar. Clicking it will make the markdown and the preview appear side-by-side",
             "meta": "https://meta.stackexchange.com/q/253112",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*?tab*",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*tab=*",
             "settings": [{
                 "id": "sbsByDefault",
                 "type": "checkbox",
@@ -254,7 +254,7 @@
             "extended_description": "Adds checkboxes to add canned messages for edit revisions when editing. You can make *your own* canned responses by clicking the 'Edit Reasons' button that is added to the Help dropdown menu in the topbar",
             "meta": "https://meta.stackexchange.com/q/190461",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions*?tab*",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions*tab=*",
             "feature_packs": ["power_user"]
         }, {
             "name": "editReasonTooltip",
@@ -262,7 +262,7 @@
             "extended_description": "When a post is edited, the editor is displayed underneath the post. This feature will show what the last revision's comment was as a tooltip when you hover over 'edited' underneath a post in 'edited [date] at [time]'",
             "meta": "https://meta.stackexchange.com/q/2315",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["power_user"],
             "usesApi": true
         }, {
@@ -271,14 +271,14 @@
             "extended_description": "",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "kbdAndBullets",
             "desc": "Add KBD and list buttons to editor toolbar",
             "extended_description": "Adds a kbd and bullet icon to the markdown editor toolbar that lets you surround the selected text with KBD tags or listify's the current selection",
             "meta": "https://meta.stackexchange.com/q/102841",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*?tab*"
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*tab=*"
         }, {
             "name": "titleEditDiff",
             "desc": "Make title edits show separately rather than merged in edit suggestions",
@@ -291,7 +291,7 @@
             "extended_description": "Enables the inline editor on all sites, even if you don't have 2k rep there yet. Note: this feature may not work on Firefox.",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }],
         "Flags": [{
             "name": "flagOutcomeTime",
@@ -349,7 +349,7 @@
             "desc": "Add an arrow to linked posts in the sidebar to show whether they are linked to or linked from",
             "meta": "https://meta.stackexchange.com/q/276235",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions*?tab*,*://chat.*.com/*,SE1.0",
+            "exclude": "*://*/questions*tab=*,*://chat.*.com/*,SE1.0",
             "usesApi": true
         }, {
             "name": "hotNetworkQuestionsFiltering",
@@ -413,21 +413,21 @@
             "extended_description": "Pulse effect when hovering over the upvote/downvote/favourite buttons. Currently only implemented natively on Android.SE.",
             "meta": "https://meta.stackexchange.com/q/252685",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["major_ui"]
         }, {
             "name": "stickyVoteButtons",
             "desc": "Make vote buttons next to posts sticky whilst scrolling on that post",
             "meta": "https://meta.stackexchange.com/a/35047",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "disableVoteButtons",
             "desc": "Disable vote buttons on your own posts and deleted posts, which you cannot vote on",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }],
         "Extras": [{
             "name": "linkedPostsInline",
@@ -435,14 +435,15 @@
             "extended_description": "Adds a button next to links to posts on the same site that expand to show the post inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
+            "usesApi": true
         }, {
             "name": "parseCrossSiteLinks",
             "desc": "Parse titles to links cross-SE-sites",
             "extended_description": "Detects links to other questions on SE sites and converts them to their title",
             "meta": "https://meta.stackexchange.com/q/251183",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
             "usesApi": true
         }, {
             "name": "quickAuthorInfo",
@@ -458,7 +459,7 @@
             "extended_description": "When you click 'share' under a post, this displays a referral link, which incorporates your user ID. This option strips your user ID from the displayed link, preventing inadvertent privacy leaks when disseminating the link via copy-paste. The social-media sharing buttons are unaffected, since the lack of privacy is obvious.",
             "meta": "https://meta.stackexchange.com/q/74274",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "shareLinksMarkdown",
@@ -466,7 +467,7 @@
             "extended_description": "When you click 'share' under a post, this will convert the URL given to a markdown-friendly version, with the post name as the link text. This feature also automatically copies the converted string to your clipboard",
             "meta": "https://meta.stackexchange.com/q/126544",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "sortByBountyAmount",
             "desc": "Add an option to filter bounties by their amount",
@@ -517,7 +518,7 @@
             "desc": "Add a button to code in posts to let you copy it",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions*?tab*,*://chat.*.com/*"
+            "exclude": "*://*/questions*tab=*,*://chat.*.com/*"
         }, {
             "name": "dailyReviewBar",
             "desc": "Add a progress bar showing how many reviews you have left in the day",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -35,7 +35,7 @@
             "extended_description": "Highlight the username of a commenter if they have posted an answer on that page.",
             "meta": "https://meta.stackexchange.com/q/19574",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
             "name": "displayName",
@@ -48,7 +48,7 @@
             "desc": "Make bounty box draggable",
             "meta": "https://meta.stackexchange.com/q/170125",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "highlightQuestions",
             "desc": "Change highlighting for questions with favourite tags",
@@ -63,7 +63,7 @@
             "extended_description": "If the question you are currently viewing is HOT, a flame icon is added next to the title",
             "meta": "https://meta.stackexchange.com/q/245390",
             "match": "*://*/questions/*,*://*/search*,*://*/?",
-            "exclude": "SE1.0,*://*/questions/ask,*://meta.*/*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://meta.*/*",
             "usesApi": true
         }, {
             "name": "localTimestamps",
@@ -111,7 +111,7 @@
             "desc": "Differentiate spoilers from empty blockquotes",
             "meta": "https://meta.stackexchange.com/q/104085",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "standOutDupeCloseMigrated",
             "desc": "Add highlighted tags to closed/on hold/duplicate/migrated questions on question lists",
@@ -133,19 +133,19 @@
             "desc": "Improve answer visibility by listing top answers",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "unspoil",
             "desc": "Add a link to the bottom of a post to reveal all spoilers in a post",
             "meta": "https://meta.stackexchange.com/q/249808",
-            "match": "*://*/questions/*,*://*/questions*tab=*,*://chat.*.com/*",
-            "exclude": "SE1.0"
+            "match": "*://*/questions*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "addTimelineAndRevisionLinks",
             "desc": "Add timeline and revision links to the bottom of each post for quick access to them",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"]
         }, {
             "name": "showTagWikiLinkOnTagPopup",
@@ -172,7 +172,7 @@
             "extended_description": "When clicking on an image that is hosted on Stack Exchange's imgur account, a modal will open showing a larger version of the image. If you still want to open the image in a new tab, there is a 'source' link in the modal.",
             "meta": "",
             "match": "*://*/questions/*,*://*/review/*",
-            "exclude": "*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }],
         "Comments": [{
             "name": "autoShowCommentImages",
@@ -180,39 +180,39 @@
             "extended_description": "This feature will automatically detect comments with links to imgur and will display them inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "commentReplies",
             "desc": "Add reply links to comments for quick replying (without having to type someone's username)",
             "meta": "https://meta.stackexchange.com/q/74778",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"]
         }, {
             "name": "commentShortcuts",
             "desc": "Use Ctrl+I,B,K (to italicise, bolden and add code backticks) in comments",
             "meta": "https://meta.stackexchange.com/q/14756",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "confirmNavigateAway",
             "desc": "Add a confirmation dialog when navigating away on pages whilst still typing a comment",
             "meta": "https://meta.stackexchange.com/q/252205",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "copyCommentsLink",
             "desc": "Copy 'show x more comments' link to the top",
             "meta": "https://meta.stackexchange.com/q/55020",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "moveBounty",
-            "desc": "Move the 'start a bounty' link to before the comments",
+            "desc": "Move the 'start a bounty' link before the comments",
             "meta": "https://meta.stackexchange.com/q/234095",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "showCommentScores",
             "desc": "Show your comment and comment replies scores in your profile tabs",
@@ -226,14 +226,14 @@
             "desc": "Add a darker border underneath comments if there are some hidden after it",
             "meta": "https://meta.stackoverflow.com/q/296582",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"]
         }, {
             "name": "onlyShowCommentActionsOnHover",
             "desc": "Only show the comment actions (flag/upvote) when hovering over a comment",
             "meta": "https://meta.stackexchange.com/q/312794",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }],
         "Editing": [{
             "name": "addSBSBtn",
@@ -241,7 +241,7 @@
             "extended_description": "An 'SBS' button is added to the right of the markdown editor toolbar. Clicking it will make the markdown and the preview appear side-by-side",
             "meta": "https://meta.stackexchange.com/q/253112",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*tab=*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "settings": [{
                 "id": "sbsByDefault",
                 "type": "checkbox",
@@ -254,7 +254,7 @@
             "extended_description": "Adds checkboxes to add canned messages for edit revisions when editing. You can make *your own* canned responses by clicking the 'Edit Reasons' button that is added to the Help dropdown menu in the topbar",
             "meta": "https://meta.stackexchange.com/q/190461",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions*tab=*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"]
         }, {
             "name": "editReasonTooltip",
@@ -262,7 +262,7 @@
             "extended_description": "When a post is edited, the editor is displayed underneath the post. This feature will show what the last revision's comment was as a tooltip when you hover over 'edited' underneath a post in 'edited [date] at [time]'",
             "meta": "https://meta.stackexchange.com/q/2315",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"],
             "usesApi": true
         }, {
@@ -271,14 +271,14 @@
             "extended_description": "",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "kbdAndBullets",
             "desc": "Add KBD and list buttons to editor toolbar",
             "extended_description": "Adds a kbd and bullet icon to the markdown editor toolbar that lets you surround the selected text with KBD tags or listify's the current selection",
             "meta": "https://meta.stackexchange.com/q/102841",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*tab=*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "titleEditDiff",
             "desc": "Make title edits show separately rather than merged in edit suggestions",
@@ -291,7 +291,7 @@
             "extended_description": "Enables the inline editor on all sites, even if you don't have 2k rep there yet. Note: this feature may not work on Firefox.",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }],
         "Flags": [{
             "name": "flagOutcomeTime",
@@ -349,7 +349,7 @@
             "desc": "Add an arrow to linked posts in the sidebar to show whether they are linked to or linked from",
             "meta": "https://meta.stackexchange.com/q/276235",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions*tab=*,*://chat.*.com/*,SE1.0",
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*,SE1.0",
             "usesApi": true
         }, {
             "name": "hotNetworkQuestionsFiltering",
@@ -413,21 +413,21 @@
             "extended_description": "Pulse effect when hovering over the upvote/downvote/favourite buttons. Currently only implemented natively on Android.SE.",
             "meta": "https://meta.stackexchange.com/q/252685",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["major_ui"]
         }, {
             "name": "stickyVoteButtons",
             "desc": "Make vote buttons next to posts sticky whilst scrolling on that post",
             "meta": "https://meta.stackexchange.com/a/35047",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "disableVoteButtons",
             "desc": "Disable vote buttons on your own posts and deleted posts, which you cannot vote on",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }],
         "Extras": [{
             "name": "linkedPostsInline",
@@ -435,7 +435,7 @@
             "extended_description": "Adds a button next to links to posts on the same site that expand to show the post inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "usesApi": true
         }, {
             "name": "parseCrossSiteLinks",
@@ -443,7 +443,7 @@
             "extended_description": "Detects links to other questions on SE sites and converts them to their title",
             "meta": "https://meta.stackexchange.com/q/251183",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "usesApi": true
         }, {
             "name": "quickAuthorInfo",
@@ -459,7 +459,7 @@
             "extended_description": "When you click 'share' under a post, this displays a referral link, which incorporates your user ID. This option strips your user ID from the displayed link, preventing inadvertent privacy leaks when disseminating the link via copy-paste. The social-media sharing buttons are unaffected, since the lack of privacy is obvious.",
             "meta": "https://meta.stackexchange.com/q/74274",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*",
             "feature_packs": ["power_user"]
         }, {
             "name": "shareLinksMarkdown",
@@ -467,7 +467,7 @@
             "extended_description": "When you click 'share' under a post, this will convert the URL given to a markdown-friendly version, with the post name as the link text. This feature also automatically copies the converted string to your clipboard",
             "meta": "https://meta.stackexchange.com/q/126544",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "sortByBountyAmount",
             "desc": "Add an option to filter bounties by their amount",
@@ -518,7 +518,7 @@
             "desc": "Add a button to code in posts to let you copy it",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions*tab=*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "dailyReviewBar",
             "desc": "Add a progress bar showing how many reviews you have left in the day",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -271,14 +271,14 @@
             "extended_description": "",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
+            "exclude": "SE1.0,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "kbdAndBullets",
             "desc": "Add KBD and list buttons to editor toolbar",
             "extended_description": "Adds a kbd and bullet icon to the markdown editor toolbar that lets you surround the selected text with KBD tags or listify's the current selection",
             "meta": "https://meta.stackexchange.com/q/102841",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
+            "exclude": "SE1.0,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "titleEditDiff",
             "desc": "Make title edits show separately rather than merged in edit suggestions",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -35,7 +35,7 @@
             "extended_description": "Highlight the username of a commenter if they have posted an answer on that page.",
             "meta": "https://meta.stackexchange.com/q/19574",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
             "name": "displayName",
@@ -48,7 +48,7 @@
             "desc": "Make bounty box draggable",
             "meta": "https://meta.stackexchange.com/q/170125",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "highlightQuestions",
             "desc": "Change highlighting for questions with favourite tags",
@@ -111,7 +111,7 @@
             "desc": "Differentiate spoilers from empty blockquotes",
             "meta": "https://meta.stackexchange.com/q/104085",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "standOutDupeCloseMigrated",
             "desc": "Add highlighted tags to closed/on hold/duplicate/migrated questions on question lists",
@@ -133,19 +133,19 @@
             "desc": "Improve answer visibility by listing top answers",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "unspoil",
             "desc": "Add a link to the bottom of a post to reveal all spoilers in a post",
             "meta": "https://meta.stackexchange.com/q/249808",
-            "match": "*://*/questions/*,*://*/questions/*?*,*://chat.*.com/*",
+            "match": "*://*/questions/*,*://*/questions*?tab*,*://chat.*.com/*",
             "exclude": "SE1.0"
         }, {
             "name": "addTimelineAndRevisionLinks",
             "desc": "Add timeline and revision links to the bottom of each post for quick access to them",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "showTagWikiLinkOnTagPopup",
@@ -172,7 +172,7 @@
             "extended_description": "When clicking on an image that is hosted on Stack Exchange's imgur account, a modal will open showing a larger version of the image. If you still want to open the image in a new tab, there is a 'source' link in the modal.",
             "meta": "",
             "match": "*://*/questions/*,*://*/review/*",
-            "exclude": "*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "*://*/questions*?tab*,*://chat.*.com/*"
         }],
         "Comments": [{
             "name": "autoShowCommentImages",
@@ -180,39 +180,39 @@
             "extended_description": "This feature will automatically detect comments with links to imgur and will display them inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "commentReplies",
             "desc": "Add reply links to comments for quick replying (without having to type someone's username)",
             "meta": "https://meta.stackexchange.com/q/74778",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "commentShortcuts",
             "desc": "Use Ctrl+I,B,K (to italicise, bolden and add code backticks) in comments",
             "meta": "https://meta.stackexchange.com/q/14756",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "confirmNavigateAway",
             "desc": "Add a confirmation dialog when navigating away on pages whilst still typing a comment",
             "meta": "https://meta.stackexchange.com/q/252205",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "copyCommentsLink",
             "desc": "Copy 'show x more comments' link to the top",
             "meta": "https://meta.stackexchange.com/q/55020",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "moveBounty",
             "desc": "Move the 'start a bounty' link to before the comments",
             "meta": "https://meta.stackexchange.com/q/234095",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "showCommentScores",
             "desc": "Show your comment and comment replies scores in your profile tabs",
@@ -226,14 +226,14 @@
             "desc": "Add a darker border underneath comments if there are some hidden after it",
             "meta": "https://meta.stackoverflow.com/q/296582",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "onlyShowCommentActionsOnHover",
             "desc": "Only show the comment actions (flag/upvote) when hovering over a comment",
             "meta": "https://meta.stackexchange.com/q/312794",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }],
         "Editing": [{
             "name": "addSBSBtn",
@@ -241,7 +241,7 @@
             "extended_description": "An 'SBS' button is added to the right of the markdown editor toolbar. Clicking it will make the markdown and the preview appear side-by-side",
             "meta": "https://meta.stackexchange.com/q/253112",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/*?*",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*?tab*",
             "settings": [{
                 "id": "sbsByDefault",
                 "type": "checkbox",
@@ -254,7 +254,7 @@
             "extended_description": "Adds checkboxes to add canned messages for edit revisions when editing. You can make *your own* canned responses by clicking the 'Edit Reasons' button that is added to the Help dropdown menu in the topbar",
             "meta": "https://meta.stackexchange.com/q/190461",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions/*?*",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions*?tab*",
             "feature_packs": ["power_user"]
         }, {
             "name": "editReasonTooltip",
@@ -262,7 +262,7 @@
             "extended_description": "When a post is edited, the editor is displayed underneath the post. This feature will show what the last revision's comment was as a tooltip when you hover over 'edited' underneath a post in 'edited [date] at [time]'",
             "meta": "https://meta.stackexchange.com/q/2315",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["power_user"],
             "usesApi": true
         }, {
@@ -271,14 +271,14 @@
             "extended_description": "",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "kbdAndBullets",
             "desc": "Add KBD and list buttons to editor toolbar",
             "extended_description": "Adds a kbd and bullet icon to the markdown editor toolbar that lets you surround the selected text with KBD tags or listify's the current selection",
             "meta": "https://meta.stackexchange.com/q/102841",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/*?*"
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions*?tab*"
         }, {
             "name": "titleEditDiff",
             "desc": "Make title edits show separately rather than merged in edit suggestions",
@@ -291,7 +291,7 @@
             "extended_description": "Enables the inline editor on all sites, even if you don't have 2k rep there yet. Note: this feature may not work on Firefox.",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }],
         "Flags": [{
             "name": "flagOutcomeTime",
@@ -349,7 +349,7 @@
             "desc": "Add an arrow to linked posts in the sidebar to show whether they are linked to or linked from",
             "meta": "https://meta.stackexchange.com/q/276235",
             "match": "*://*/questions/*",
-            "exclude": "*://*/questions/*?*,*://chat.*.com/*,SE1.0",
+            "exclude": "*://*/questions*?tab*,*://chat.*.com/*,SE1.0",
             "usesApi": true
         }, {
             "name": "hotNetworkQuestionsFiltering",
@@ -413,21 +413,21 @@
             "extended_description": "Pulse effect when hovering over the upvote/downvote/favourite buttons. Currently only implemented natively on Android.SE.",
             "meta": "https://meta.stackexchange.com/q/252685",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["major_ui"]
         }, {
             "name": "stickyVoteButtons",
             "desc": "Make vote buttons next to posts sticky whilst scrolling on that post",
             "meta": "https://meta.stackexchange.com/a/35047",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "disableVoteButtons",
             "desc": "Disable vote buttons on your own posts and deleted posts, which you cannot vote on",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }],
         "Extras": [{
             "name": "linkedPostsInline",
@@ -435,14 +435,14 @@
             "extended_description": "Adds a button next to links to posts on the same site that expand to show the post inline",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "parseCrossSiteLinks",
             "desc": "Parse titles to links cross-SE-sites",
             "extended_description": "Detects links to other questions on SE sites and converts them to their title",
             "meta": "https://meta.stackexchange.com/q/251183",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions*?tab*,*://chat.*.com/*",
             "usesApi": true
         }, {
             "name": "quickAuthorInfo",
@@ -458,7 +458,7 @@
             "extended_description": "When you click 'share' under a post, this displays a referral link, which incorporates your user ID. This option strips your user ID from the displayed link, preventing inadvertent privacy leaks when disseminating the link via copy-paste. The social-media sharing buttons are unaffected, since the lack of privacy is obvious.",
             "meta": "https://meta.stackexchange.com/q/74274",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "shareLinksMarkdown",
@@ -466,7 +466,7 @@
             "extended_description": "When you click 'share' under a post, this will convert the URL given to a markdown-friendly version, with the post name as the link text. This feature also automatically copies the converted string to your clipboard",
             "meta": "https://meta.stackexchange.com/q/126544",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "sortByBountyAmount",
             "desc": "Add an option to filter bounties by their amount",
@@ -517,7 +517,7 @@
             "desc": "Add a button to code in posts to let you copy it",
             "meta": "",
             "match": "*://*/questions/*,*://*/review*",
-            "exclude": "*://*/questions/*?*,*://chat.*.com/*"
+            "exclude": "*://*/questions*?tab*,*://chat.*.com/*"
         }, {
             "name": "dailyReviewBar",
             "desc": "Add a progress bar showing how many reviews you have left in the day",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -17,14 +17,14 @@
         }, {
             "name": "alignBadgesByClass",
             "desc": "Align badges by their class on user profile pages",
-            "meta": "http://meta.stackexchange.com/q/254607/260841",
+            "meta": "https://meta.stackexchange.com/q/254607",
             "match": "*://*/users/*",
             "exclude": "SE1.0"
         }, {
             "name": "answerTagsSearch",
             "desc": "Show tags for the question an answer belongs to on search pages (for better context)",
             "extended_description": "By default, any search results that are answers do not show its question's tags. This feature adds the question's tags underneath the result.",
-            "meta": "http://meta.stackexchange.com/questions/197874/include-tags-in-answers-entries-on-search-results",
+            "meta": "https://meta.stackexchange.com/q/197874",
             "match": "*://*.com/search*",
             "exclude": "SE1.0",
             "feature_packs": ["power_user"],
@@ -33,37 +33,38 @@
             "name": "colorAnswerer",
             "desc": "Color answerer's comments",
             "extended_description": "Highlight the username of a commenter if they have posted an answer on that page.",
-            "meta": "http://meta.stackexchange.com/questions/19574/highlight-comments-from-answer-author-in-addition-to-question-author",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "meta": "https://meta.stackexchange.com/q/19574",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
             "name": "displayName",
             "desc": "Add display name before gravatar in topbar",
-            "meta": "http://meta.stackexchange.com/questions/209992/my-username-instead-of-my-gravatar-in-the-top-bar",
+            "meta": "https://meta.stackexchange.com/q/209992",
             "match": "",
             "exclude": "*://chat.*.com/*,SE1.0"
         }, {
             "name": "dragBounty",
             "desc": "Make bounty box draggable",
-            "meta": "http://meta.stackexchange.com/questions/170125/make-bounty-custom-message-dialog-box-draggable",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "meta": "https://meta.stackexchange.com/q/170125",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "highlightQuestions",
             "desc": "Change highlighting for questions with favourite tags",
             "extended_description": "Changes the favourite tag question highlighting to be a more subtle, coloured left-border",
-            "meta": "http://meta.stackexchange.com/questions/238591/should-favorite-tag-highlighting-in-question-lists-be-changed",
+            "meta": "https://meta.stackexchange.com/q/238591",
             "match": "",
-            "exclude": "*://chat.*.com/*,*://*/questions/*",
+            "exclude": "*://chat.*.com/*,*://*/questions/*,*://*/questions/ask",
             "feature_packs": ["major_ui", "key_feature", "power_user"]
         }, {
             "name": "isQuestionHot",
             "desc": "Add a label on questions which are hot-network questions",
             "extended_description": "If the question you are currently viewing is HOT, a flame icon is added next to the title",
-            "meta": "http://meta.stackexchange.com/questions/245390/let-mods-and-10k-know-when-questions-go-hot",
+            "meta": "https://meta.stackexchange.com/q/245390",
             "match": "*://*/questions/*,*://*/search*,*://*/?",
-            "exclude": "SE1.0,*://*/questions/ask,*://meta.*/*"
+            "exclude": "SE1.0,*://*/questions/ask,*://meta.*/*,*://chat.*.com/*",
+            "usesApi": true
         }, {
             "name": "localTimestamps",
             "desc": "Convert timestamps to your local time",
@@ -79,7 +80,7 @@
          }, {
             "name": "markEmployees",
             "desc": "Add the SO logo after employee names to make them stand out",
-            "meta": "http://meta.stackexchange.com/questions/246678/should-se-staff-have-a-special-character-in-their-user-name",
+            "meta": "https://meta.stackexchange.com/q/246678",
             "match": "",
             "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask",
             "feature_packs": ["major_ui", "key_feature", "power_user"],
@@ -87,13 +88,13 @@
         }, {
             "name": "metaChatBlogStackExchangeButton",
             "desc": "Show meta and chat buttons on hover of a site under the site switcher button",
-            "meta": "http://meta.stackexchange.com/questions/256183/show-the-meta-chat-and-blog-in-the-top-bar-for-other-sites-on-hover",
+            "meta": "https://meta.stackexchange.com/q/256183",
             "match": "",
-            "exclude": ""
+            "exclude": "*://chat.*.com/*"
         }, {
             "name": "metaNewQuestionAlert",
             "desc": "Add a mod diamond to the topbar to alert you of new questions on the site's child-meta",
-            "meta": "http://meta.stackexchange.com/questions/256318/can-high-rep-users-be-allowed-to-see-meta-notifications",
+            "meta": "https://meta.stackexchange.com/q/256318",
             "match": "",
             "exclude": "*://chat.*.com/*,SE1.0",
             "feature_packs": ["power_user"],
@@ -108,22 +109,22 @@
         }, {
             "name": "spoilerTip",
             "desc": "Differentiate spoilers from empty blockquotes",
-            "meta": "http://meta.stackexchange.com/questions/104085/differentiate-spoilers-from-empty-block-quotes",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0"
+            "meta": "https://meta.stackexchange.com/q/104085",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "standOutDupeCloseMigrated",
             "desc": "Add highlighted tags to closed/on hold/duplicate/migrated questions on question lists",
             "extended_description": "Adds a coloured box at the end of a title (that replaces the standard [duplicate], etc.) in question lists to more easily tell what the state of a question is",
-            "meta": "http://meta.stackexchange.com/questions/257021/proposal-to-make-duplicate-closed-and-migrated-in-the-title-more-obvious",
-            "match": "*://*.com/,*://*.com/questions,*://*.com/questions/tagged/*",
+            "meta": "https://meta.stackexchange.com/q/257021",
+            "match": "*://*.com/,*://*.*/questions*",
             "exclude": "*://chat.*.com/*,SE1.0,*://*/review*",
             "feature_packs": ["major_ui, key_feature", "power_user"],
             "usesApi": true
         }, {
             "name": "tabularReviewerStats",
             "desc": "Display reviewer stats on /review/suggested-edits in table form",
-            "meta": "http://meta.stackexchange.com/q/276946/260841",
+            "meta": "https://meta.stackexchange.com/q/276946",
             "match": "*://*.com/review/suggested-edits/*",
             "exclude": "",
             "feature_packs": ["power_user"]
@@ -131,20 +132,20 @@
             "name": "topAnswers",
             "desc": "Improve answer visibility by listing top answers",
             "meta": "",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "unspoil",
             "desc": "Add a link to the bottom of a post to reveal all spoilers in a post",
-            "meta": "http://meta.stackexchange.com/questions/249808/add-a-way-to-reveal-all-spoiler-blocks-in-a-post-at-once",
-            "match": "*://*/questions*",
+            "meta": "https://meta.stackexchange.com/q/249808",
+            "match": "*://*/questions/*,*://*/questions/*?*,*://chat.*.com/*",
             "exclude": "SE1.0"
         }, {
             "name": "addTimelineAndRevisionLinks",
             "desc": "Add timeline and revision links to the bottom of each post for quick access to them",
             "meta": "",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "*://*/questions/ask",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "showTagWikiLinkOnTagPopup",
@@ -170,77 +171,77 @@
             "desc": "Open imgur images as larger modals on click",
             "extended_description": "When clicking on an image that is hosted on Stack Exchange's imgur account, a modal will open showing a larger version of the image. If you still want to open the image in a new tab, there is a 'source' link in the modal.",
             "meta": "",
-            "match": "*://*/questions*,*://*/review/*",
-            "exclude": ""
+            "match": "*://*/questions/*,*://*/review/*",
+            "exclude": "*://*/questions/*?*,*://chat.*.com/*"
         }],
         "Comments": [{
             "name": "autoShowCommentImages",
             "desc": "View linked images (to imgur) in comments inline",
             "extended_description": "This feature will automatically detect comments with links to imgur and will display them inline",
             "meta": "",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "commentReplies",
             "desc": "Add reply links to comments for quick replying (without having to type someone's username)",
-            "meta": "http://meta.stackexchange.com/questions/74778/add-reply-link-to-comment-that-pre-populates-comment-box-with-username",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "meta": "https://meta.stackexchange.com/q/74778",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "commentShortcuts",
             "desc": "Use Ctrl+I,B,K (to italicise, bolden and add code backticks) in comments",
-            "meta": "http://meta.stackexchange.com/questions/14756/formatting-keyboard-shortcuts-for-comments",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "meta": "https://meta.stackexchange.com/q/14756",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "confirmNavigateAway",
             "desc": "Add a confirmation dialog when navigating away on pages whilst still typing a comment",
-            "meta": "http://meta.stackexchange.com/questions/252205/add-are-you-sure-you-want-to-navigate-away-from-this-page-when-writing-a-comm",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0"
+            "meta": "https://meta.stackexchange.com/q/252205",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "copyCommentsLink",
             "desc": "Copy 'show x more comments' link to the top",
-            "meta": "http://meta.stackexchange.com/questions/55020/add-a-show-more-comments-button-to-the-top-of-a-list-of-comments",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0"
+            "meta": "https://meta.stackexchange.com/q/55020",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "moveBounty",
             "desc": "Move the 'start a bounty' link to before the comments",
-            "meta": "http://meta.stackexchange.com/questions/234095/can-we-move-start-a-bounty-to-a-more-intuitive-location",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0"
+            "meta": "https://meta.stackexchange.com/q/234095",
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "showCommentScores",
             "desc": "Show your comment and comment replies scores in your profile tabs",
             "extended_description": "Adds a button next to comments in your profile's responses/activity tabs that when clicked, show you the score of your comment",
-            "meta": "http://meta.stackexchange.com/questions/38285/display-the-number-of-comment-upvotes-in-recent-activity-pages",
+            "meta": "https://meta.stackexchange.com/q/38285",
             "match": "*://*/users/*",
-            "exclude": "SE1.0",
+            "exclude": "SE1.0,*://chat.*.com/*",
             "usesApi": true
         }, {
             "name": "hiddenCommentsIndicator",
             "desc": "Add a darker border underneath comments if there are some hidden after it",
-            "meta": "http://meta.stackoverflow.com/q/296582/3541881",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0",
+            "meta": "https://meta.stackoverflow.com/q/296582",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "onlyShowCommentActionsOnHover",
             "desc": "Only show the comment actions (flag/upvote) when hovering over a comment",
             "meta": "https://meta.stackexchange.com/q/312794",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "*://*/questions/ask"
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }],
         "Editing": [{
             "name": "addSBSBtn",
             "desc": "Add a button to the editor toolbar to start side-by-side editing",
             "extended_description": "An 'SBS' button is added to the right of the markdown editor toolbar. Clicking it will make the markdown and the preview appear side-by-side",
-            "meta": "http://meta.stackexchange.com/questions/253112/the-discourse-layout-for-side-by-side-markdown-preview",
+            "meta": "https://meta.stackexchange.com/q/253112",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/*?*",
             "settings": [{
                 "id": "sbsByDefault",
                 "type": "checkbox",
@@ -251,45 +252,46 @@
             "name": "editComment",
             "desc": "Pre-defined edit comment options (checkboxes)",
             "extended_description": "Adds checkboxes to add canned messages for edit revisions when editing. You can make *your own* canned responses by clicking the 'Edit Reasons' button that is added to the Help dropdown menu in the topbar",
-            "meta": "http://meta.stackexchange.com/questions/190461/improve-the-editing-flow-with-predefined-options-for-edit-summary",
+            "meta": "https://meta.stackexchange.com/q/190461",
             "match": "*://*/questions/*",
-            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/ask,*://*/questions/*?*",
             "feature_packs": ["power_user"]
         }, {
             "name": "editReasonTooltip",
             "desc": "Add a tooltip to posts showing the last revision's comment",
             "extended_description": "When a post is edited, the editor is displayed underneath the post. This feature will show what the last revision's comment was as a tooltip when you hover over 'edited' underneath a post in 'edited [date] at [time]'",
-            "meta": "http://meta.stackexchange.com/questions/2315/show-reason-for-edit-without-clicking-through-to-diff",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
-            "feature_packs": ["power_user"]
+            "meta": "https://meta.stackexchange.com/q/2315",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
+            "feature_packs": ["power_user"],
+            "usesApi": true
         }, {
             "name": "findAndReplace",
             "desc": "Add a find & replace feature to the markdown editor",
             "extended_description": "",
             "meta": "",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0"
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "kbdAndBullets",
             "desc": "Add KBD and list buttons to editor toolbar",
             "extended_description": "Adds a kbd and bullet icon to the markdown editor toolbar that lets you surround the selected text with KBD tags or listify's the current selection",
-            "meta": "http://meta.stackexchange.com/questions/102841/key-equivalent-for-kbd-kbd",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "*://chat.*.com/*,SE1.0"
+            "meta": "https://meta.stackexchange.com/q/102841",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "*://chat.*.com/*,SE1.0,*://*/questions/*?*"
         }, {
             "name": "titleEditDiff",
             "desc": "Make title edits show separately rather than merged in edit suggestions",
-            "meta": "http://meta.stackexchange.com/questions/135710/please-show-changed-titles-separately-in-edit-diffs",
-            "match": "*://*.com/review/suggested-edits*",
+            "meta": "https://meta.stackexchange.com/q/135710",
+            "match": "*://*.*/review/suggested-edits*",
             "exclude": ""
         }, {
             "name": "inlineEditorEverywhere",
             "desc": "Inline editor regardless of reputation",
             "extended_description": "Enables the inline editor on all sites, even if you don't have 2k rep there yet. Note: this feature may not work on Firefox.",
             "meta": "",
-            "match": "*://*/questions*",
-            "exclude": "*://*/questions/ask"
+            "match": "*://*/questions/*",
+            "exclude": "*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }],
         "Flags": [{
             "name": "flagOutcomeTime",
@@ -307,7 +309,7 @@
         }, {
             "name": "flagPercentageBar",
             "desc": "Show the total percentage of helpful flags as a coloured bar on the Flag Summary Page",
-            "meta": "http://meta.stackoverflow.com/questions/310881/overall-percentage-of-helpful-flags",
+            "meta": "https://meta.stackoverflow.com/q/310881",
             "match": "*://*/users/*",
             "exclude": "*://chat.*.com/*,SE1.0",
             "feature_packs": ["power_user"]
@@ -345,9 +347,10 @@
         }, {
             "name": "linkedToFrom",
             "desc": "Add an arrow to linked posts in the sidebar to show whether they are linked to or linked from",
-            "meta": "http://meta.stackexchange.com/q/276235/260841",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0"
+            "meta": "https://meta.stackexchange.com/q/276235",
+            "match": "*://*/questions/*",
+            "exclude": "*://*/questions/*?*,*://chat.*.com/*,SE1.0",
+            "usesApi": true
         }, {
             "name": "hotNetworkQuestionsFiltering",
             "desc": "Filter the hot network questions by their attributes",
@@ -375,12 +378,13 @@
             "extended_description": "When hovering over a question title in the Hot Network Questions sidebar, the question's tags from the originating site will be shown",
             "meta": "",
             "match": "*://*/questions/*",
-            "exclude": "SE1.0"
+            "exclude": "SE1.0",
+            "usesApi": true
         }],
         "Chat": [{
             "name": "chatEasyAccess",
             "desc": "Add buttons to user profiles to change user write access directly from a chat room",
-            "meta": "http://meta.stackexchange.com/q/203480/260841",
+            "meta": "https://meta.stackexchange.com/q/203480",
             "match": "*://chat.*.com/*",
             "exclude": ""
         },  {
@@ -392,7 +396,7 @@
         }, {
             "name": "renameChat",
             "desc": "Prepend 'Chat - ' to chat tabs' titles",
-            "meta": "http://meta.stackexchange.com/questions/246289/change-the-browser-tab-title-on-chat-pages-to-chat-sitename-or-chat-room-name",
+            "meta": "https://meta.stackexchange.com/q/246289",
             "match": "*://chat.*.com/*",
             "exclude": ""
         }, {
@@ -407,66 +411,66 @@
             "name": "betterCSS",
             "desc": "Add extra CSS for animation actions on voting and favourite buttons",
             "extended_description": "Pulse effect when hovering over the upvote/downvote/favourite buttons. Currently only implemented natively on Android.SE.",
-            "meta": "http://meta.stackexchange.com/questions/252685/i-want-to-have-those-voting-animations-like-on-android-se-pretty-please",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0",
+            "meta": "https://meta.stackexchange.com/q/252685",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["major_ui"]
         }, {
             "name": "stickyVoteButtons",
             "desc": "Make vote buttons next to posts sticky whilst scrolling on that post",
-            "meta": "http://meta.stackexchange.com/a/35047/260841",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "meta": "https://meta.stackexchange.com/a/35047",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["major_ui, key_feature", "power_user"]
         }, {
             "name": "disableVoteButtons",
             "desc": "Disable vote buttons on your own posts and deleted posts, which you cannot vote on",
             "meta": "",
-            "match": "*://*/questions*",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "match": "*://*/questions/*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }],
         "Extras": [{
             "name": "linkedPostsInline",
             "desc": "Display linked posts inline by clicking on an arrow",
             "extended_description": "Adds a button next to links to posts on the same site that expand to show the post inline",
             "meta": "",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0"
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "parseCrossSiteLinks",
             "desc": "Parse titles to links cross-SE-sites",
             "extended_description": "Detects links to other questions on SE sites and converts them to their title",
-            "meta": "http://meta.stackexchange.com/questions/251183/parse-question-links-from-other-se-sites",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0",
+            "meta": "https://meta.stackexchange.com/q/251183",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/*?*,*://chat.*.com/*",
             "usesApi": true
         }, {
             "name": "quickAuthorInfo",
             "desc": "Show when the post's author was last seen and whether they are registered",
             "meta": "",
             "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "exclude": "SE1.0,*://*/questions/ask,*://chat.*.com/*",
             "feature_packs": ["power_user"],
             "usesApi": true
         }, {
             "name": "shareLinksPrivacy",
             "desc": "Remove your user ID from the 'share' link",
             "extended_description": "When you click 'share' under a post, this displays a referral link, which incorporates your user ID. This option strips your user ID from the displayed link, preventing inadvertent privacy leaks when disseminating the link via copy-paste. The social-media sharing buttons are unaffected, since the lack of privacy is obvious.",
-            "meta": "https://meta.stackexchange.com/questions/74274/privacy-leak-in-permalink",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask",
+            "meta": "https://meta.stackexchange.com/q/74274",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*",
             "feature_packs": ["power_user"]
         }, {
             "name": "shareLinksMarkdown",
             "desc": "Change 'share' link to format of [post-name](url)",
             "extended_description": "When you click 'share' under a post, this will convert the URL given to a markdown-friendly version, with the post name as the link text. This feature also automatically copies the converted string to your clipboard",
-            "meta": "http://meta.stackexchange.com/questions/126544/add-a-second-share-button-to-posts-with-comment-ready-links",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": "SE1.0,*://*/questions/ask"
+            "meta": "https://meta.stackexchange.com/q/126544",
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "SE1.0,*://*/questions/ask,*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "sortByBountyAmount",
             "desc": "Add an option to filter bounties by their amount",
-            "meta": "http://meta.stackexchange.com/questions/7753/please-give-us-the-ability-to-sort-featured-tab-by-bounty-amount",
+            "meta": "https://meta.stackexchange.com/q/7753",
             "match": "",
             "exclude": "*://*/users/*,*://chat.*.com/*,SE1.0,*://*/questions/*,*://*/review*"
         }, {
@@ -512,8 +516,8 @@
             "name": "copyCode",
             "desc": "Add a button to code in posts to let you copy it",
             "meta": "",
-            "match": "*://*/questions*,*://*/review*",
-            "exclude": ""
+            "match": "*://*/questions/*,*://*/review*",
+            "exclude": "*://*/questions/*?*,*://chat.*.com/*"
         }, {
             "name": "dailyReviewBar",
             "desc": "Add a progress bar showing how many reviews you have left in the day",

--- a/sox.features.js
+++ b/sox.features.js
@@ -631,15 +631,13 @@
     confirmNavigateAway: function() {
       // Description: For adding a 'are you ure you want to go away' confirmation on pages where you have started writing something
 
-      if (window.location.href.indexOf('questions/') >= 0) {
-        $(window).bind('beforeunload', () => {
-          const textarea = document.querySelector('.comment-form textarea');
-          if (textarea && textarea.value) {
-            return 'Do you really want to navigate away? Anything you have written will be lost!';
-          }
-          return;
-        });
-      }
+      $(window).bind('beforeunload', () => {
+        const textarea = document.querySelector('.comment-form textarea');
+        if (textarea && textarea.value) {
+          return 'Do you really want to navigate away? Anything you have written will be lost!';
+        }
+        return;
+      });
     },
 
     sortByBountyAmount: function() {


### PR DESCRIPTION
Basically, exclude chat and stuff like https://stackoverflow.com/questions?tab=Unanswered, etc.

Minor changes:
- Simplify Meta links
- Migrate to HTTPS
- Add usesApi to some features that use the API

That needs review, tested too much, but I guess I must have missed something.