### PR TITLE
Dark mode style fixes

### DIFF
--- a/sox.css
+++ b/sox.css
@@ -394,7 +394,7 @@
 /*linkedPostsInline for the displayed post text; https://github.com/shu8/Stack-Overflow-Optional-Features/issues/48 */
 
 .linkedPostsInline-loaded-body-sox {
-    background-color: aliceblue;
+    background-color: var(--blue-050);
     border-radius: 20px;
     overflow-wrap: break-word;
     width: auto;
@@ -501,7 +501,7 @@
     display: none;
     /* relative position prevents code from being in front of button */
     position: relative;
-    background-color: #eff0f1;
+    background-color: var(--highlight-bg);
     margin-left: -15px;
 }
 

--- a/sox.css
+++ b/sox.css
@@ -529,9 +529,10 @@
 /*colorAnswerer -- for the username*/
 
 .sox-answerer {
-    color: rgba(0, 50, 200, 1);
-    background-color: rgba(220, 220, 220, 1);
+    color: var(--blue-700);
+    background-color: var(--bc-medium);
     padding: 1px 5px !important;
+    border-radius: 3px;
 }
 
 /*hotNetworkQuestionsFiltering -- for the questions to hide*/


### PR DESCRIPTION
The first commit (linkedPostsInline and copyCode) shouldn't change anything in light mode. For colorAnswerer, I used a slightly paler blue for the text color, and added rounded corners to match the style used for the asker.