### PR TITLE
Tools page customization

### DIFF
--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -159,7 +159,7 @@
             "desc": "Customize the appearance of the tools page on Stack Overflow",
             "extended_description": "This page is accessible to users who have earned 10 000 reputation on Stack Overflow",
             "meta": "",
-            "match": "https://stackoverflow.com/tools",
+            "match": "https://*/tools",
             "exclude": "",
             "settings": [{
                 "id": "listCount",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -154,6 +154,30 @@
             "meta": "",
             "match": "*://*/questions/*",
             "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
+        }, {
+            "name": "customizeToolsPageLists",
+            "desc": "Customize the appearance of the tools page on Stack Overflow",
+            "extended_description": "This page is accessible to users who have earned 10 000 reputation on Stack Overflow",
+            "meta": "",
+            "match": "https://stackoverflow.com/tools",
+            "exclude": "",
+            "settings": [{
+                "id": "listCount",
+                "type": "text",
+                "desc": "Number of items to show in delete/undelete vote lists"
+            }, {
+                "id": "filterInvalid",
+                "type": "checkbox",
+                "desc": "Exclude items you are unable to vote on from delete/undelete lists"
+            }, {
+                "id": "filterTypeQuestions",
+                "type": "checkbox",
+                "desc": "Exclude questions from delete/undelete lists"
+            }, {
+                "id": "filterTypeAnswers",
+                "type": "checkbox",
+                "desc": "Exclude answers from delete/undelete lists"
+            }]
         }],
         "Comments": [{
             "name": "autoShowCommentImages",

--- a/sox.features.info.json
+++ b/sox.features.info.json
@@ -156,8 +156,8 @@
             "exclude": "*://*/questions/ask,*://*/questions/tagged*,*://*/questions/greatest-hits*"
         }, {
             "name": "customizeToolsPageLists",
-            "desc": "Customize the appearance of the tools page on Stack Overflow",
-            "extended_description": "This page is accessible to users who have earned 10 000 reputation on Stack Overflow",
+            "desc": "Customize the appearance of the /tools page on all sites",
+            "extended_description": "This feature will allow you to filter what posts are shown on the /tools page, which is accessible to all users with >10k reputation on a site.",
             "meta": "",
             "match": "https://*/tools",
             "exclude": "",

--- a/sox.features.js
+++ b/sox.features.js
@@ -1609,7 +1609,7 @@
       // Description: Hides the Community Bulletin module from the sidebar
 
       const element = document.querySelector('#sidebar .s-sidebarwidget');
-      if (element.innerText.contains('The Overflow Blog')) element.remove();
+      if (element?.innerText.contains('The Overflow Blog')) element.remove();
     },
 
     hideJustHotMetaPosts: function() {
@@ -2620,6 +2620,26 @@
       const answers = document.querySelector("#answers-header h2").innerText.split(' ')[0];
       const toInsert = '<div class="grid--cell ws-nowrap mb8 ml16"><span class="fc-light mr4">Answers</span> ' + answers + '</div>';
       document.querySelector(".d-flex.fw-wrap").insertAdjacentHTML("beforeEnd", toInsert);
-    }
+    },
+
+    customizeToolsPageLists: function(settings) {
+        const trimLists = function(table) {
+            if (settings.filterInvalid) {
+                table.querySelectorAll("td.tagged-ignored").forEach(cell => cell.parentNode.remove());
+            }
+            if (settings.filterTypeQuestions) {
+                table.querySelectorAll("a.question-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
+            }
+            if (settings.filterTypeAnswers) {
+                table.querySelectorAll("a.answer-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
+            }
+            const listCount = settings.listCount || 3;
+            const rows = table.querySelectorAll("tr");
+            rows.forEach((row, i) => row.classList.toggle("collapsing", i >= listCount));
+        };
+        // tables are populated by XHR after page loads
+        sox.helpers.observe(Array.from(document.querySelectorAll("div.island")), "table.summary-table", trimLists);
+        // just in case we come in after a table has been loaded already
+        document.querySelectorAll("table.summary-table").forEach(table => trimLists(table));
   };
 })(window.sox = window.sox || {}, jQuery);

--- a/sox.features.js
+++ b/sox.features.js
@@ -2623,23 +2623,25 @@
     },
 
     customizeToolsPageLists: function(settings) {
-        const trimLists = function(table) {
-            if (settings.filterInvalid) {
-                table.querySelectorAll("td.tagged-ignored").forEach(cell => cell.parentNode.remove());
-            }
-            if (settings.filterTypeQuestions) {
-                table.querySelectorAll("a.question-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
-            }
-            if (settings.filterTypeAnswers) {
-                table.querySelectorAll("a.answer-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
-            }
-            const listCount = settings.listCount || 3;
-            const rows = table.querySelectorAll("tr");
-            rows.forEach((row, i) => row.classList.toggle("collapsing", i >= listCount));
-        };
-        // tables are populated by XHR after page loads
-        sox.helpers.observe(Array.from(document.querySelectorAll("div.island")), "table.summary-table", trimLists);
-        // just in case we come in after a table has been loaded already
-        document.querySelectorAll("table.summary-table").forEach(table => trimLists(table));
+      const trimLists = function(table) {
+        if (settings.filterInvalid) {
+          table.querySelectorAll("td.tagged-ignored").forEach(cell => cell.parentNode.remove());
+        }
+        if (settings.filterTypeQuestions) {
+          table.querySelectorAll("a.question-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
+        }
+        if (settings.filterTypeAnswers) {
+          table.querySelectorAll("a.answer-hyperlink").forEach(cell => cell.parentNode.parentNode.remove());
+        }
+        const listCount = settings.listCount || 3;
+        const rows = table.querySelectorAll("tr");
+        rows.forEach((row, i) => row.classList.toggle("collapsing", i >= listCount));
+      };
+      // tables are populated by XHR after page loads
+    
+      sox.helpers.observe(Array.from(document.querySelectorAll("div.island")), "table.summary-table", trimLists);
+      // just in case we come in after a table has been loaded already
+      document.querySelectorAll("table.summary-table").forEach(table => trimLists(table));
+    }
   };
 })(window.sox = window.sox || {}, jQuery);


### PR DESCRIPTION
Implement feature request for customization of lists at https://stackoverflow.com/tools as described in #505.

One thing lacking is inability to add radio buttons to the settings to select question/answer/all. Like you can add a single setting of type "radio" but without ability to link them together it's kind of useless.

Also was unable to get sox.helpers.addAjaxListener to work, but didn't spend much time figuring out why since I just went with the mutation observer instead.